### PR TITLE
Feature/#205 add mock data for starting a transaction

### DIFF
--- a/backend-app/docs/openapi.yaml
+++ b/backend-app/docs/openapi.yaml
@@ -329,7 +329,7 @@ paths:
                   zipCode: zipCode
                   city: city
                   country: country
-                  userId: userId
+                  userID: userID
         '400':
           description: Bad request
         '401':
@@ -357,7 +357,7 @@ paths:
                   zipCode: zipCode
                   city: city
                   country: country
-                  userId: userId
+                  userID: userID
         '400':
           description: Bad request
         '401':
@@ -545,56 +545,148 @@ paths:
                   $ref: '#/components/schemas/Charger'
         '404':
           description: Error message
-  /transactions/{transactionId}:
-    parameters:
-      - in: path
-        name: transactionId
-        schema:
-          type: string
-        required: true
-    get:
-      tags:
-        - Transactions
-      summary: Transaction
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json: {}
   /transactions:
     post:
       tags:
         - Transactions
-      summary: Transaction
+      summary: Create a transaction
       description: |-
-        userID = string,
-
-        chargerID = int
-
-        isKlarnaPayment = bool
-
-        pricePerKwh = string
+        Creates a transaction that can be started using the `transactionID` returned
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userID:
+                  type: string
+                  example: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+                chargerID:
+                  type: integer
+                  example: 100001
+                isKlarnaPayment:
+                  type: boolean
+                  example: true
+                pricePerKwh:
+                  type: number
+                  example: 333
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactionID:
+                    type: integer
+                    example: 9999
+        '400':
+          description: Error message
+        '500':
+          description: Error message
+  /transactions/start/{transactionID}:
+    parameters:
+      - in: path
+        name: transactionID
+        schema:
+          type: integer
+        required: true
+    put:
+      tags:
+        - Transactions
+      summary: Start a transaction
+      description: |-
+        Starts a transaction
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+        '400':
+          description: Error message
+        '500':
+          description: Error message
+  /transactions/{transactionID}:
+    parameters:
+      - in: path
+        name: transactionID
+        schema:
+          type: integer
+        required: true
+    get:
+      tags:
+        - Transactions
+      summary: Get status of a transaction
+      description: |-
+        Gets the status of a transaction
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+        '404':
+          description: Transaction not found
+        '500':
+          description: Error message
+  /transactions/stop/{transactionID}:
+    parameters:
+      - in: path
+        name: transactionID
+        schema:
+          type: integer
+        required: true
+    put:
+      tags:
+        - Transactions
+      summary: Stop a transaction
+      description: |-
+        Stops a transaction
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+        '400':
+          description: Error message
+        '500':
+          description: Error message
+  /transactions/payment/{transactionID}:
+    parameters:
+      - in: path
+        name: transactionID
+        schema:
+          type: integer
+        required: true
+    put:
+      tags:
+        - Transactions
+      summary: Update payment
       requestBody:
         content:
           application/json:
             schema:
               type: object
               example:
-                userID: '1'
-                chargerID: 100001
-                isKlarnaPayment: true
-                pricePerKwh: '333'
+                transactionID: '1'
+                paymentId: '2'
       responses:
         '200':
           description: Successful response
           content:
             application/json: {}
-  /transactions/chargingStatus/{transactionId}:
+  /transactions/chargingStatus/{transactionID}:
     parameters:
       - in: path
-        name: transactionId
+        name: transactionID
         schema:
-          type: string
+          type: integer
         required: true
     put:
       tags:
@@ -638,28 +730,28 @@ paths:
           description: Error message
         '500':
           description: Error message
-  /transactions/userTransactions/{userId}:
+  /transactions/userTransactions/{userID}:
     parameters:
       - in: path
-        name: userId
+        name: userID
         schema:
-          type: string
+          type: integer
         required: true
     get:
       tags:
         - Transactions
-      summary: Transaction by userId
+      summary: Transaction by userID
       responses:
         '200':
           description: Successful response
           content:
             application/json: {}
-  /transactions/chargerTransactions/{chargerId}:
+  /transactions/chargerTransactions/{chargerID}:
     parameters:
       - in: path
-        name: chargerId
+        name: chargerID
         schema:
-          type: string
+          type: integer
         required: true
     get:
       tags:
@@ -670,70 +762,10 @@ paths:
           description: Successful response
           content:
             application/json: {}
-  /transactions/payment/{transactionId}:
+  /reservations/{reservationID}:
     parameters:
       - in: path
-        name: transactionId
-        schema:
-          type: string
-        required: true
-    put:
-      tags:
-        - Transactions
-      summary: Update payment
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              example:
-                transactionId: '1'
-                paymentId: '2'
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json: {}
-  /transactions/stop/{transactionId}:
-    parameters:
-      - in: path
-        name: transactionId
-        schema:
-          type: string
-        required: true
-    put:
-      tags:
-        - Transactions
-      summary: Stop
-      requestBody:
-        content: {}
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json: {}
-  /transactions/start/{transactionId}:
-    parameters:
-      - in: path
-        name: transactionId
-        schema:
-          type: string
-        required: true
-    put:
-      tags:
-        - Transactions
-      summary: Start
-      requestBody:
-        content: {}
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json: {}
-  /reservations/{reservationId}:
-    parameters:
-      - in: path
-        name: reservationId
+        name: reservationID
         schema:
           type: string
         required: true
@@ -741,7 +773,7 @@ paths:
       deprecated: true
       tags:
         - Reservations (deprecated)
-      summary: Reservation by id
+      summary: Reservation by ID
       responses:
         '200':
           description: Successful response
@@ -758,10 +790,10 @@ paths:
             schema:
               type: object
               example:
-                chargerId: 1
+                chargerID: 1
                 connectorId: 1
                 idTag: 1
-                reservationId: 1
+                reservationID: 1
                 parentIdTag: 1
       responses:
         '200':
@@ -782,10 +814,10 @@ paths:
           description: Error message
         '500':
           description: Error message
-  /reservations/userReservation/{userId}:
+  /reservations/userReservation/{userID}:
     parameters:
       - in: path
-        name: userId
+        name: userID
         schema:
           type: string
         required: true
@@ -793,7 +825,7 @@ paths:
       deprecated: true
       tags:
         - Reservations (deprecated)
-      summary: Reservation by userId
+      summary: Reservation by userID
       responses:
         '200':
           description: Successful response
@@ -820,10 +852,10 @@ paths:
           description: Successful response
           content:
             application/json: {}
-  /reservations/chargerReservation/{chargerId}:
+  /reservations/chargerReservation/{chargerID}:
     parameters:
       - in: path
-        name: chargerId
+        name: chargerID
         schema:
           type: string
         required: true
@@ -831,7 +863,7 @@ paths:
       deprecated: true
       tags:
         - Reservations (deprecated)
-      summary: Reservation by chargerId
+      summary: Reservation by chargerID
       responses:
         '200':
           description: Successful response
@@ -936,10 +968,10 @@ paths:
           description: Unauthorized
           content:
             application/json: {}
-  /invoices/users/{userId}:
+  /invoices/users/{userID}:
     parameters:
       - in: path
-        name: userId
+        name: userID
         schema:
           type: string
         required: true
@@ -1140,6 +1172,49 @@ components:
         klarnaReservationAmount:
           type: number
           example: 400
+    Transaction:
+      type: object
+      properties:
+        transactionID:
+          type: integer
+          example: 1
+        isKlarnaPayment:
+          type: boolean
+          example: false
+        kwhTransfered:
+          type: number
+          example: 50
+        currentChargePercentage:
+          type: number
+          example: 79
+        pricePerKwh:
+          type: string
+          example: '123.00'
+        timestamp:
+          type: integer
+          example: 1663663253
+        paymentID:
+          type: string
+          example: null
+        userID:
+          type: string
+          example: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+        session_id:
+          type: string
+          example: null
+        client_token:
+          type: string
+          example: null
+        paymentConfirmed:
+          type: boolean
+          example: null
+        meterStart:
+          type: integer
+          example: 1
+        chargerID:
+          type: integer
+          example: 100002
+
   securitySchemes:
     bearerAuth:
       type: http

--- a/backend-app/src/presentation-layer/charge-point-router-api.js
+++ b/backend-app/src/presentation-layer/charge-point-router-api.js
@@ -19,8 +19,8 @@ module.exports = function ({ databaseInterfaceChargePoint }) {
     })
 
     router.get('/:id', function (request, response) {
-        const chargePointId = request.params.id
-        databaseInterfaceChargePoint.getChargePoint(chargePointId, function (error, chargePoint) {
+        const chargePointID = request.params.id
+        databaseInterfaceChargePoint.getChargePoint(chargePointID, function (error, chargePoint) {
             if (error.length == 0 && chargePoint.length == 0) {
                 response.status(404).end()
             } else if (error.length == 0) {
@@ -47,8 +47,8 @@ module.exports = function ({ databaseInterfaceChargePoint }) {
         })
     })
     router.delete('/:id', checkJwt, checkIfAdmin, function (request, response) {
-        const chargePointId = request.params.id;
-        databaseInterfaceChargePoint.removeChargePoint(chargePointId, function (error, chargePointRemoved) {
+        const chargePointID = request.params.id;
+        databaseInterfaceChargePoint.removeChargePoint(chargePointID, function (error, chargePointRemoved) {
             if (error.length == 0 && chargePointRemoved) {
                 response.status(204).json()
             } else if (error.length == 0 && !chargePointRemoved) {
@@ -60,9 +60,9 @@ module.exports = function ({ databaseInterfaceChargePoint }) {
     })
 
     router.put('/:id', checkJwt, checkIfAdmin, function (request, response) {
-        const chargePointId = request.params.id;
+        const chargePointID = request.params.id;
         const { name, location, price } = request.body;
-        databaseInterfaceChargePoint.updateChargePoint(chargePointId, name, location, price, function (error, chargePoint) {
+        databaseInterfaceChargePoint.updateChargePoint(chargePointID, name, location, price, function (error, chargePoint) {
             if (error.length === 0 && chargePoint === undefined) {
                 response.status(404).json(error);
             } else if (error.length > 0) {

--- a/backend-app/src/presentation-layer/chargers-router-api.js
+++ b/backend-app/src/presentation-layer/chargers-router-api.js
@@ -3,111 +3,111 @@ const checkJwt = require("./middleware/jwt.middleware");
 const checkIfAdmin = require("./middleware/admin.middleware");
 
 module.exports = function ({ databaseInterfaceCharger }) {
-  const router = express.Router();
+    const router = express.Router();
 
-  router.get("/", async function (request, response) {
-    databaseInterfaceCharger.getChargers(function (error, chargers) {
-      if (error.length > 0) {
-        response.status(500).json(error);
-      } else {
-        response.status(200).json(chargers);
-      }
+    router.get("/", async function (request, response) {
+        databaseInterfaceCharger.getChargers(function (error, chargers) {
+            if (error.length > 0) {
+                response.status(500).json(error);
+            } else {
+                response.status(200).json(chargers);
+            }
+        });
     });
-  });
-  router.get("/available", function (request, response) {
-    databaseInterfaceCharger.getAvailableChargers(function (errors, chargers) {
-      if (errors.length > 0) {
-        response.status(404).json(errors);
-      } else {
-        response.status(200).json(chargers);
-      }
+    router.get("/available", function (request, response) {
+        databaseInterfaceCharger.getAvailableChargers(function (errors, chargers) {
+            if (errors.length > 0) {
+                response.status(404).json(errors);
+            } else {
+                response.status(200).json(chargers);
+            }
+        });
     });
-  });
 
-  router.get("/serial/:serialNumber", function (request, response) {
-    const serialNumber = request.params.serialNumber;
-    databaseInterfaceCharger.getChargerBySerialNumber(
-      serialNumber,
-      function (error, charger) {
-        if (error.length > 0) {
-          response.status(500).json(error);
-        } else {
-          response.status(200).json(charger);
-        }
-      }
-    );
-  });
-
-  router.get("/:id", function (request, response) {
-    const id = request.params.id;
-    databaseInterfaceCharger.getCharger(id, function (errors, charger) {
-      if (errors.length == 0 && charger.length == 0) {
-        response.status(404).end();
-      } else if (errors.length == 0) {
-        response.status(200).json(charger);
-      } else {
-        response.status(500).json(errors);
-      }
+    router.get("/serial/:serialNumber", function (request, response) {
+        const serialNumber = request.params.serialNumber;
+        databaseInterfaceCharger.getChargerBySerialNumber(
+            serialNumber,
+            function (error, charger) {
+                if (error.length > 0) {
+                    response.status(500).json(error);
+                } else {
+                    response.status(200).json(charger);
+                }
+            }
+        );
     });
-  });
 
-  router.post("/", checkJwt, checkIfAdmin, function (request, response) {
-    const chargerPointId = request.body.chargePointID;
-    const location = request.body.location;
-    const serialNumber = request.body.serialNumber;
+    router.get("/:id", function (request, response) {
+        const id = request.params.id;
+        databaseInterfaceCharger.getCharger(id, function (errors, charger) {
+            if (errors.length == 0 && charger.length == 0) {
+                response.status(404).end();
+            } else if (errors.length == 0) {
+                response.status(200).json(charger);
+            } else {
+                response.status(500).json(errors);
+            }
+        });
+    });
 
-    databaseInterfaceCharger.addCharger(
-      chargerPointId,
-      serialNumber,
-      location,
-      function (errorCodes, chargerId) {
-        if (errorCodes.length == 0) {
-          response.status(201).json(chargerId);
-        } else {
-          if (
-            errorCodes.includes("internalError") ||
-            errorCodes.includes("dbError")
-          ) {
-            response.status(500).json(errorCodes);
-          } else {
-            response.status(404).json(errorCodes);
-          }
-        }
-      }
-    );
-  });
+    router.post("/", checkJwt, checkIfAdmin, function (request, response) {
+        const chargerPointID = request.body.chargePointID;
+        const location = request.body.location;
+        const serialNumber = request.body.serialNumber;
 
-  router.delete("/:id", checkJwt, checkIfAdmin, function (request, response) {
-    const id = request.params.id;
-    databaseInterfaceCharger.removeCharger(
-      id,
-      function (errors, isChargerDeleted) {
-        if (errors.length == 0 && isChargerDeleted) {
-          response.status(204).json();
-        } else if (errors.length == 0 && !isChargerDeleted) {
-          response.status(404).json();
-        } else {
-          response.status(500).json(errors);
-        }
-      }
-    );
-  });
+        databaseInterfaceCharger.addCharger(
+            chargerPointID,
+            serialNumber,
+            location,
+            function (errorCodes, chargerId) {
+                if (errorCodes.length == 0) {
+                    response.status(201).json(chargerId);
+                } else {
+                    if (
+                        errorCodes.includes("internalError") ||
+                        errorCodes.includes("dbError")
+                    ) {
+                        response.status(500).json(errorCodes);
+                    } else {
+                        response.status(404).json(errorCodes);
+                    }
+                }
+            }
+        );
+    });
 
-  router.put("/:id", checkJwt, checkIfAdmin, function (request, response) {
-    const chargerId = request.params.id;
-    const newStatus = request.body.status;
-    databaseInterfaceCharger.updateChargerStatus(
-      chargerId,
-      newStatus,
-      function (errors, charger) {
-        if (errors.length == 0) {
-          response.status(200).json(charger);
-        } else {
-          response.status(400).json(errors);
-        }
-      }
-    );
-  });
+    router.delete("/:id", checkJwt, checkIfAdmin, function (request, response) {
+        const id = request.params.id;
+        databaseInterfaceCharger.removeCharger(
+            id,
+            function (errors, isChargerDeleted) {
+                if (errors.length == 0 && isChargerDeleted) {
+                    response.status(204).json();
+                } else if (errors.length == 0 && !isChargerDeleted) {
+                    response.status(404).json();
+                } else {
+                    response.status(500).json(errors);
+                }
+            }
+        );
+    });
 
-  return router;
+    router.put("/:id", checkJwt, checkIfAdmin, function (request, response) {
+        const chargerID = request.params.id;
+        const newStatus = request.body.status;
+        databaseInterfaceCharger.updateChargerStatus(
+            chargerID,
+            newStatus,
+            function (errors, charger) {
+                if (errors.length == 0) {
+                    response.status(200).json(charger);
+                } else {
+                    response.status(400).json(errors);
+                }
+            }
+        );
+    });
+
+    return router;
 };

--- a/backend-app/src/presentation-layer/reservations-router-api.js
+++ b/backend-app/src/presentation-layer/reservations-router-api.js
@@ -7,8 +7,8 @@ module.exports = function ({ databaseInterfaceReservations, ocppInterface }) {
     const router = express.Router()
 
     router.get('/:id', function (request, response) {
-        const reservationId = request.params.id
-        databaseInterfaceReservations.getReservation(reservationId, function (errors, reservation) {
+        const reservationID = request.params.id
+        databaseInterfaceReservations.getReservation(reservationID, function (errors, reservation) {
             if (errors.length == 0 && reservation.length == 0) {
                 response.status(404).end()
             } else if (errors.length == 0) {
@@ -20,13 +20,13 @@ module.exports = function ({ databaseInterfaceReservations, ocppInterface }) {
     })
 
     router.get('/userReservation/:userID', function (request, response) {
-        const userId = request.params.userID
+        const userID = request.params.userID
 
         ////////////////////////////////////////////////
         // A user can only view its own reservations? //
         ////////////////////////////////////////////////
 
-        databaseInterfaceReservations.getReservationForUser(userId, function (error, userReservation) {
+        databaseInterfaceReservations.getReservationForUser(userID, function (error, userReservation) {
             if (error.length == 0 && userReservation.length == 0) {
                 response.status(404).end()
             } else if (error.length == 0) {
@@ -38,8 +38,8 @@ module.exports = function ({ databaseInterfaceReservations, ocppInterface }) {
     })
 
     router.get('/chargerReservation/:chargerID', function (request, response) {
-        const chargerId = request.params.chargerID
-        databaseInterfaceReservations.getReservationForCharger(chargerId, function (error, chargerReservation) {
+        const chargerID = request.params.chargerID
+        databaseInterfaceReservations.getReservationForCharger(chargerID, function (error, chargerReservation) {
             if (error.length == 0 && chargerReservation.length == 0) {
                 response.status(404).end()
             } else if (error.length == 0) {
@@ -70,8 +70,8 @@ module.exports = function ({ databaseInterfaceReservations, ocppInterface }) {
         //////////////////////////////////////////////////
         // A user can only remove its own reservations? //
         //////////////////////////////////////////////////
-        const reservationId = request.params.id
-        databaseInterfaceReservations.removeReservation(reservationId, function (errors, isReservationDeleted) {
+        const reservationID = request.params.id
+        databaseInterfaceReservations.removeReservation(reservationID, function (errors, isReservationDeleted) {
             if (errors.length == 0 && isReservationDeleted) {
                 response.status(204).json()
             } else if (errors.length == 0 && !isReservationDeleted) {
@@ -83,12 +83,12 @@ module.exports = function ({ databaseInterfaceReservations, ocppInterface }) {
     })
 
     router.put('/:chargerId', function (request, response) {
-        const chargerId = request.params.chargerId
-        const connectorId = request.body.connectorId
+        const chargerID = request.params.chargerId
+        const connectorID = request.body.connectorId
         const idTag = request.body.idTag
-        const reservationId = request.body.reservationId
+        const reservationID = request.body.reservationId
         const parentIdTag = request.body.parentIdTag
-        ocppInterface.reserveNow(chargerId, connectorId, idTag, reservationId, parentIdTag, function (error, resp) {
+        ocppInterface.reserveNow(chargerID, connectorID, idTag, reservationID, parentIdTag, function (error, resp) {
             if (error === null && resp != null) {
                 response.status(201).json(resp)
             } else {

--- a/backend-app/src/presentation-layer/transactions-router-api.js
+++ b/backend-app/src/presentation-layer/transactions-router-api.js
@@ -135,38 +135,21 @@ module.exports = function ({ databaseInterfaceTransactions }) {
         const authorization_token = request.body.authorization_token;
 
         if (transactionID == 9999) {
-            const data = [
-                {
-                    "transactionID": 1,
-                    "isKlarnaPayment": false,
-                    "kwhTransfered": Math.floor(Math.random() * 100) + 1, // Random number between 0 and 100
-                    "currentChargePercentage": Math.floor(Math.random() * 101), // Random number between 0 and 100
-                    "pricePerKwh": (Math.random() * 100).toFixed(2), // Random number between 0 and 100 with 2 decimal places
-                    "timestamp": 1663663253,
-                    "paymentID": null,
-                    "userID": "1",
-                    "session_id": null,
-                    "client_token": null,
-                    "paymentConfirmed": null,
-                    "meterStart": 1,
-                    "chargerID": 100000
-                }
-            ];
-            response.status(200).json(data)
+            const data = getMockTransaction();
+            response.status(200).json(data);
+            return;
         }
-        else {
-            databaseInterfaceTransactions.createKlarnaOrder(transactionID, authorization_token, function (error, klarnaOrder) {
-                console.log(error);
-                console.log(klarnaOrder);
-                if (error.length === 0) {
-                    response.status(201).json(klarnaOrder)
-                } else if (error.includes("internalError") || error.includes("dbError")) {
-                    response.status(500).json(error)
-                } else {
-                    response.status(400).json(error);
-                }
-            })
-        }
+        databaseInterfaceTransactions.createKlarnaOrder(transactionID, authorization_token, function (error, klarnaOrder) {
+            console.log(error);
+            console.log(klarnaOrder);
+            if (error.length === 0) {
+                response.status(200).json(klarnaOrder)
+            } else if (error.includes("internalError") || error.includes("dbError")) {
+                response.status(500).json(error)
+            } else {
+                response.status(400).json(error);
+            }
+        })
     })
 
     router.post('/session', function (request, response) {

--- a/backend-app/src/presentation-layer/transactions-router-api.js
+++ b/backend-app/src/presentation-layer/transactions-router-api.js
@@ -7,8 +7,29 @@ module.exports = function ({ databaseInterfaceTransactions }) {
     const router = express.Router()
     router.get('/:id', function (request, response) {
 
-        const transactionId = request.params.id
-        databaseInterfaceTransactions.getTransaction(transactionId, function (errors, transaction) {
+        const transactionID = request.params.id
+
+        if (transactionID == 9999) {
+            const data = [
+                {
+                    "transactionID": 1,
+                    "isKlarnaPayment": false,
+                    "kwhTransfered": Math.floor(Math.random() * 100) + 1, // Random number between 0 and 100
+                    "currentChargePercentage": Math.floor(Math.random() * 101), // Random number between 0 and 100
+                    "pricePerKwh": (Math.random() * 100).toFixed(2), // Random number between 0 and 100 with 2 decimal places
+                    "timestamp": 1663663253,
+                    "paymentID": null,
+                    "userID": "1",
+                    "session_id": null,
+                    "client_token": null,
+                    "paymentConfirmed": null,
+                    "meterStart": 1,
+                    "chargerID": 100000
+                }
+            ];
+            response.status(200).json(data)
+        }
+        databaseInterfaceTransactions.getTransaction(transactionID, function (errors, transaction) {
             if (errors.length == 0 && transaction.length == 0) {
                 response.status(404).end()
             } else if (errors.length == 0) {
@@ -21,8 +42,8 @@ module.exports = function ({ databaseInterfaceTransactions }) {
 
     router.get('/userTransactions/:userID', function (request, response) {
 
-        const userId = request.params.userID
-        databaseInterfaceTransactions.getTransactionsForUser(userId, function (errors, userTransaction) {
+        const userID = request.params.userID
+        databaseInterfaceTransactions.getTransactionsForUser(userID, function (errors, userTransaction) {
             if (errors.length == 0 && userTransaction.length == 0) {
                 response.status(404).end()
             } else if (errors.length == 0) {
@@ -35,8 +56,8 @@ module.exports = function ({ databaseInterfaceTransactions }) {
 
     router.get('/chargerTransactions/:chargerID', function (request, response) {
 
-        const chargerId = request.params.chargerID
-        databaseInterfaceTransactions.getTransactionsForCharger(chargerId, function (errors, chargerTransaction) {
+        const chargerID = request.params.chargerID
+        databaseInterfaceTransactions.getTransactionsForCharger(chargerID, function (errors, chargerTransaction) {
             if (errors.length == 0 && chargerTransaction.length == 0) {
                 response.status(404).end()
             } else if (errors.length == 0) {
@@ -50,23 +71,30 @@ module.exports = function ({ databaseInterfaceTransactions }) {
     router.post('/', function (request, response) {
 
         const { userID, chargerID, isKlarnaPayment, pricePerKwh } = request.body;
-        databaseInterfaceTransactions.addTransaction(userID, chargerID, isKlarnaPayment, pricePerKwh, function (errors, transaction) {
-            if (errors.length > 0) {
-                response.status(400).json(errors)
-            } else if (transaction) {
-                response.status(201).json(transaction)
-            } else {
-                response.status(500).json(errors)
-            }
-        })
+        if (chargerID == 100000) {
+            response.status(200).json(9999)
+        }
+        else {
+            databaseInterfaceTransactions.addTransaction(userID, chargerID, isKlarnaPayment, pricePerKwh, function (errors, transaction) {
+                if (errors.length > 0) {
+                    response.status(400).json(errors)
+                } else if (transaction) {
+                    response.status(201).json(transaction)
+                } else {
+                    response.status(500).json(errors)
+                }
+            })
+        }
+
+
     })
 
 
     router.put('/payment/:transactionID', function (request, response) {
 
-        const transactionId = request.params.transactionID
-        const paymentId = request.body.paymentID
-        databaseInterfaceTransactions.updateTransactionPayment(transactionId, paymentId, function (error, updatedTransactionPayment) {
+        const transactionID = request.params.transactionID
+        const paymentID = request.body.paymentID
+        databaseInterfaceTransactions.updateTransactionPayment(transactionID, paymentID, function (error, updatedTransactionPayment) {
             if (error.length == 0) {
                 response.status(201).json(updatedTransactionPayment)
             } else {
@@ -80,10 +108,10 @@ module.exports = function ({ databaseInterfaceTransactions }) {
     })
 
     router.put('/chargingStatus/:transactionID', function (request, response) {
-        const transactionId = request.params.transactionID
+        const transactionID = request.params.transactionID
         const kwhTransfered = request.body.kwhTransfered
         const currentChargePercentage = request.body.currentChargePercentage
-        databaseInterfaceTransactions.updateTransactionChargingStatus(transactionId, kwhTransfered, currentChargePercentage, function (error, updatedTransaction) {
+        databaseInterfaceTransactions.updateTransactionChargingStatus(transactionID, kwhTransfered, currentChargePercentage, function (error, updatedTransaction) {
             if (error.length == 0) {
                 response.status(201).json(updatedTransaction)
             } else {
@@ -101,17 +129,39 @@ module.exports = function ({ databaseInterfaceTransactions }) {
         const transactionID = request.params.transactionID
         const authorization_token = request.body.authorization_token;
 
-        databaseInterfaceTransactions.createKlarnaOrder(transactionID, authorization_token, function (error, klarnaOrder) {
-            console.log(error);
-            console.log(klarnaOrder);
-            if (error.length === 0) {
-                response.status(201).json(klarnaOrder)
-            } else if (error.includes("internalError") || error.includes("dbError")) {
-                response.status(500).json(error)
-            } else {
-                response.status(400).json(error);
-            }
-        })
+        if (transactionID == 9999) {
+            const data = [
+                {
+                    "transactionID": 1,
+                    "isKlarnaPayment": false,
+                    "kwhTransfered": Math.floor(Math.random() * 100) + 1, // Random number between 0 and 100
+                    "currentChargePercentage": Math.floor(Math.random() * 101), // Random number between 0 and 100
+                    "pricePerKwh": (Math.random() * 100).toFixed(2), // Random number between 0 and 100 with 2 decimal places
+                    "timestamp": 1663663253,
+                    "paymentID": null,
+                    "userID": "1",
+                    "session_id": null,
+                    "client_token": null,
+                    "paymentConfirmed": null,
+                    "meterStart": 1,
+                    "chargerID": 100000
+                }
+            ];
+            response.status(200).json(data)
+        }
+        else {
+            databaseInterfaceTransactions.createKlarnaOrder(transactionID, authorization_token, function (error, klarnaOrder) {
+                console.log(error);
+                console.log(klarnaOrder);
+                if (error.length === 0) {
+                    response.status(201).json(klarnaOrder)
+                } else if (error.includes("internalError") || error.includes("dbError")) {
+                    response.status(500).json(error)
+                } else {
+                    response.status(400).json(error);
+                }
+            })
+        }
     })
 
     router.post('/session', function (request, response) {
@@ -131,15 +181,38 @@ module.exports = function ({ databaseInterfaceTransactions }) {
 
     router.put('/stop/:transactionID', function (request, response) {
         const transactionID = request.params.transactionID
-        databaseInterfaceTransactions.finalizeKlarnaOrder(transactionID, function (error, stoppedTransaction) {
-            if (error.length > 0) {
-                response.status(400).json(error)
-            } else if (stoppedTransaction) {
-                response.status(200).json(stoppedTransaction)
-            } else {
-                response.status(500).json(error)
-            }
-        })
+
+        if (transactionID == 9999) {
+            const data =
+            {
+                "transactionID": 1,
+                "isKlarnaPayment": false,
+                "kwhTransfered": Math.floor(Math.random() * 100) + 1, // Random number between 0 and 100
+                "currentChargePercentage": Math.floor(Math.random() * 101), // Random number between 0 and 100
+                "pricePerKwh": (Math.random() * 100).toFixed(2), // Random number between 0 and 100 with 2 decimal places
+                "timestamp": 1663663253,
+                "paymentID": null,
+                "userID": "1",
+                "session_id": null,
+                "client_token": null,
+                "paymentConfirmed": null,
+                "meterStart": 1,
+                "chargerID": 100000
+            };
+            response.status(200).json(data)
+        }
+        else {
+            databaseInterfaceTransactions.finalizeKlarnaOrder(transactionID, function (error, stoppedTransaction) {
+                if (error.length > 0) {
+                    response.status(400).json(error)
+                } else if (stoppedTransaction) {
+                    response.status(200).json(stoppedTransaction)
+                } else {
+                    response.status(500).json(error)
+                }
+            })
+        }
+
     })
 
     return router


### PR DESCRIPTION
## Describe your changes

- Respond with mock data on requests to `POST /transactions`, passing a specific `transactionID` (`9999`) every time, when a specific `chargerID` (`100000`) is used.
- Respond with mock data on requests to `PUT /transactions/start/{transactionID}` when the `transactionID` is a certain value (`9999`).
- Respond with mock data on requests to `GET /transactions/{transactionID}` when the `transactionID` is a certain value (`9999`).
- Respond with mock data on requests to `PUT /transactions/stop/{transactionID}` when the `transactionID` is a certain value (`9999`).

- Update API documentation in Swagger to accurately reflect the `transaction` part of the API 

## Issue ticket number and preferably a link

#205

## This change belongs to the following squad(s)
- Database
- [X] HTTP
- [X] OCPP

## I have created unit tests for my code
- Yes
- [X] No
- No, I need help with this

## Checklist before creating my pull request
- [X] My code is properly commented where needed
- [X] I have updated the documentation with my changes/additions
- [X] I have reviewed my code before creating this pull request
- [X] I have made sure that I am targeting the correct branch
