### PR TITLE
Feature/#226 add backwards compatibility

### DIFF
--- a/backend-app/src/data-access-layer/charge-points-repository.js
+++ b/backend-app/src/data-access-layer/charge-points-repository.js
@@ -21,11 +21,11 @@ module.exports = function({ databaseInit }) {
 
     }
 
-    exports.addChargePoint = function(name, address, coordinates, callback) {
+    exports.addChargePoint = function(name, address, location, callback) {
         const chargePoint = {
             name: name,
             address: address,
-            coordinates: coordinates
+            location: location
         }
 
         databaseInit.ChargePoints.create(chargePoint)
@@ -56,7 +56,7 @@ module.exports = function({ databaseInit }) {
 
     }
 
-    exports.updateChargePoint = function(chargePointID, name, address, coordinates, callback) {
+    exports.updateChargePoint = function(chargePointID, name, address, location, callback) {
         let updateProperties = {}
 
         if (name != null) {
@@ -67,8 +67,8 @@ module.exports = function({ databaseInit }) {
             updateProperties.address = address
         }
 
-        if (coordinates != null) {
-            updateProperties.coordinates = coordinates
+        if (location != null) {
+            updateProperties.location = location
         }
 
         databaseInit.ChargePoints.update(updateProperties, {

--- a/backend-app/src/data-access-layer/charge-points-repository.js
+++ b/backend-app/src/data-access-layer/charge-points-repository.js
@@ -4,7 +4,11 @@ module.exports = function({ databaseInit }) {
 
     exports.getChargePoint = function(chargePointID, callback) {
         databaseInit.ChargePoints.findOne({ where: { chargePointID: chargePointID }, raw: true })
-            .then(chargePoint => callback([], chargePoint))
+            .then(chargePoint => {
+                chargePoint.price = 500_00
+                chargePoint.klarnaReservationAmount = 0
+                callback([], chargePoint)
+            })
             .catch(e => {
                 console.log(e)
                 callback(e, [])
@@ -13,7 +17,13 @@ module.exports = function({ databaseInit }) {
 
     exports.getChargePoints = function(callback) {
         databaseInit.ChargePoints.findAll({ raw: true })
-            .then(chargePoints => callback([], chargePoints))
+            .then(chargePoints => {
+                chargePoints.forEach(chargePoint => {
+                    chargePoint.price = 500_00
+                    chargePoint.klarnaReservationAmount = 0
+                })
+                callback([], chargePoints)
+            })
             .catch(e => {
                 console.log(e)
                 callback(e, [])

--- a/backend-app/src/data-access-layer/chargers-repository.js
+++ b/backend-app/src/data-access-layer/chargers-repository.js
@@ -38,11 +38,11 @@ module.exports = function ({ databaseInit }) {
             })
     }
 
-    exports.addCharger = function (chargePointID, serialNumber, coordinates, callback) {
+    exports.addCharger = function (chargePointID, serialNumber, location, callback) {
         const charger = {
             chargePointID: chargePointID,
             serialNumber: serialNumber,
-            coordinates: coordinates,
+            location: location,
             status: 'Reserved'
         }
 

--- a/backend-app/src/data-access-layer/db.js
+++ b/backend-app/src/data-access-layer/db.js
@@ -29,7 +29,7 @@ const Chargers = sequelize.define('Chargers', {
         primaryKey: true,
         allowNull: false
     },
-    coordinates: {
+    location: {
       type: DataTypes.ARRAY(DataTypes.FLOAT),
       unique: false,
       allowNull: false,
@@ -157,7 +157,7 @@ const ChargePoints = sequelize.define(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    coordinates: {
+    location: {
       type: DataTypes.ARRAY(DataTypes.FLOAT),
       unique: false,
       allowNull: false,
@@ -269,89 +269,89 @@ sequelize.sync().then(function () {
       ChargePoints.create({
         name: "Airport Parking, Jönköping",
         address: "Flygplansvägen",
-        coordinates: [57.749812214261034, 14.070100435207065],
+        location: [57.749812214261034, 14.070100435207065],
       });
       ChargePoints.create({
         name: "Jönköping University",
         address: "Gjuterigatan 5",
-        coordinates: [57.777714, 14.16301],
+        location: [57.777714, 14.16301],
       });
       ChargePoints.create({
         name: "Nässjö Centralstation",
         address: "Järnvägsgatan 26",
-        coordinates: [57.652328901782795, 14.694810832097543],
+        location: [57.652328901782795, 14.694810832097543],
       });
       ChargePoints.create({
         name: "Coop, Forserum",
         address: "Jönköpingsvägen 2",
-        coordinates: [57.70022044183724, 14.475150415104222],
+        location: [57.70022044183724, 14.475150415104222],
       });
       Chargers.create({
         connectorID: 100000,
-        coordinates: [57.777714, 14.16301],
+        location: [57.777714, 14.16301],
         serialNumber: "testchargeralwaysconnected",
         status: "Available",
         chargePointID: 1, //Jönköping University
       });
       Chargers.create({
         connectorID: 100001,
-        coordinates: [57.777714, 14.16301],
+        location: [57.777714, 14.16301],
         serialNumber: "abc111",
         status: "Available",
         chargePointID: 1, //Jönköping University
       });
       Chargers.create({
         connectorID: 100002,
-        coordinates: [57.777714, 14.16301],
+        location: [57.777714, 14.16301],
         serialNumber: "abc112",
         status: "Available",
         chargePointID: 1, //Jönköping University
       });
       Chargers.create({
         connectorID: 100003,
-        coordinates: [57.777714, 14.16301],
+        location: [57.777714, 14.16301],
         serialNumber: "abc113",
         status: "Available",
         chargePointID: 1, //Jönköping University
       });
       Chargers.create({
         connectorID: 100004,
-        coordinates: [57.652328901782795, 14.694810832097543],
+        location: [57.652328901782795, 14.694810832097543],
         serialNumber: "abc114",
         status: "Available",
         chargePointID: 2, //Nässjö Centralstation
       });
       Chargers.create({
         connectorID: 100005,
-        coordinates: [57.652328901782795, 14.694810832097543],
+        location: [57.652328901782795, 14.694810832097543],
         serialNumber: "abc115",
         status: "Available",
         chargePointID: 2, //Nässjö Centralstation
       });
       Chargers.create({
         connectorID: 100006,
-        coordinates: [57.70022044183724, 14.475150415104222],
+        location: [57.70022044183724, 14.475150415104222],
         serialNumber: "abc116",
         status: "Available",
         chargePointID: 3, //Coop, Forserum
       });
       Chargers.create({
         connectorID: 100007,
-        coordinates: [57.749812214261034, 14.070100435207065],
+        location: [57.749812214261034, 14.070100435207065],
         serialNumber: "abc117",
         status: "Available",
         chargePointID: 4, // Airport Parking, Jönköping
       });
       Chargers.create({
         connectorID: 100008,
-        coordinates: [57.749812214261034, 14.070100435207065],
+        location: [57.749812214261034, 14.070100435207065],
         serialNumber: "abc118",
         status: "Available",
         chargePointID: 4, // Airport Parking, Jönköping
       });
       Chargers.create({
         connectorID: 100009,
-        coordinates: [57.749812214261034, 14.070100435207065],
+        location: [57.749812214261034, 14.070100435207065],
         serialNumber: "abc119",
         status: "Available",
         chargePointID: 4, // Airport Parking, Jönköping

--- a/backend-app/src/database-Interface/database-interface-charge-points.js
+++ b/backend-app/src/database-Interface/database-interface-charge-points.js
@@ -35,12 +35,12 @@ module.exports = function ({ dataAccessLayerChargePoints, dbErrorCheck, chargePo
         })
     }
 
-    exports.addChargePoint = function (name, address, coordinates, callback) {
-        const validationErrors = chargePointValidation.getAddChargePointValidation(name, address, coordinates)
+    exports.addChargePoint = function (name, address, location, callback) {
+        const validationErrors = chargePointValidation.getAddChargePointValidation(name, address, location)
         if (validationErrors.length > 0) {
             callback(validationErrors, [])
         } else {
-            dataAccessLayerChargePoints.addChargePoint(name, address, coordinates, function (error, chargePointID) {
+            dataAccessLayerChargePoints.addChargePoint(name, address, location, function (error, chargePointID) {
                 if (Object.keys(error).length > 0) {
                     dbErrorCheck.checkError(error, function (errorCode) {
                         callback(errorCode, [])
@@ -69,12 +69,12 @@ module.exports = function ({ dataAccessLayerChargePoints, dbErrorCheck, chargePo
         }
     }
 
-    exports.updateChargePoint = function (chargePointID, name, address, coordinates, callback) {
-        const validationErrors = chargePointValidation.getAddChargePointValidation(name, address, coordinates)
+    exports.updateChargePoint = function (chargePointID, name, address, location, callback) {
+        const validationErrors = chargePointValidation.getAddChargePointValidation(name, address, location)
         if (validationErrors.length > 0) {
             callback(validationErrors, [])
         } else {
-            dataAccessLayerChargePoints.updateChargePoint(chargePointID, name, address, coordinates, function (error, updatedChargePoint) {
+            dataAccessLayerChargePoints.updateChargePoint(chargePointID, name, address, location, function (error, updatedChargePoint) {
                 if (Object.keys(error).length > 0) {
                     dbErrorCheck.checkError(error, function (errorCode) {
                         callback(errorCode, [])

--- a/backend-app/src/database-Interface/database-interface-chargers.js
+++ b/backend-app/src/database-Interface/database-interface-chargers.js
@@ -71,13 +71,13 @@ module.exports = function ({ dataAccessLayerChargers, dbErrorCheck, chargerValid
         })
     }
 
-    exports.addCharger = function (chargePointID, serialNumber, coordinates, callback) {
-        const ValidationErrors = chargerValidation.getAddChargerValidation(coordinates, serialNumber, chargePointID)
+    exports.addCharger = function (chargePointID, serialNumber, location, callback) {
+        const ValidationErrors = chargerValidation.getAddChargerValidation(location, serialNumber, chargePointID)
         if (ValidationErrors.length > 0) {
             callback(ValidationErrors, [])
             return
         }
-        dataAccessLayerChargers.addCharger(chargePointID, serialNumber, coordinates, function (error, connectorID) {
+        dataAccessLayerChargers.addCharger(chargePointID, serialNumber, location, function (error, connectorID) {
             if (Object.keys(error).length > 0) {
                 dbErrorCheck.checkError(error, function (errorCode) {
                     callback(errorCode, [])

--- a/backend-app/src/database-Interface/tests/database-interface-charge-points.test.js
+++ b/backend-app/src/database-Interface/tests/database-interface-charge-points.test.js
@@ -34,8 +34,8 @@ describe("addChargePoint", () => {
     test("Add a Charge Point", (done) => {
         const name = "SuperCharger"
         const address = "Lidl"
-        const coordinates = [31.351, 124.23]
-        databaseInterfaceChargePoints.addChargePoint(name, address, coordinates, (error, addedChargePoint) => {
+        const location = [31.351, 124.23]
+        databaseInterfaceChargePoints.addChargePoint(name, address, location, (error, addedChargePoint) => {
             if (Object.keys(error).length > 0) {
                 done(error);
                 return;
@@ -66,8 +66,8 @@ describe("updateChargePoint", () => {
         const chargePointID = 23
         const name = "SuperCharger"
         const address = "Lidl"
-        const coordinates = [31.351, 124.23]
-        databaseInterfaceChargePoints.updateChargePoint(chargePointID, name, address, coordinates, (error, updatedChargePoint) => {
+        const location = [31.351, 124.23]
+        databaseInterfaceChargePoints.updateChargePoint(chargePointID, name, address, location, (error, updatedChargePoint) => {
             if (Object.keys(error).length > 0) {
                 done(error);
                 return;

--- a/backend-app/src/database-Interface/tests/database-interface-chargers.test.js
+++ b/backend-app/src/database-Interface/tests/database-interface-chargers.test.js
@@ -62,9 +62,9 @@ describe("getAvailableChargers", () => {
 describe("addCharger", () => {
     const chargePointID = 100001
     const serialNumber = "bca245"
-    const coordinates = [23.12, 55.43]
+    const location = [23.12, 55.43]
     test("Get all Chargers with status of 'Available'", (done) => {
-        databaseInterfaceChargers.addCharger(chargePointID, serialNumber, coordinates, (error, charger) => {
+        databaseInterfaceChargers.addCharger(chargePointID, serialNumber, location, (error, charger) => {
             if (Object.keys(error).length > 0) {
                 done(error);
                 return;

--- a/backend-app/src/database-Interface/validation/charge-point-validation.js
+++ b/backend-app/src/database-Interface/validation/charge-point-validation.js
@@ -9,7 +9,7 @@ module.exports = function({}) {
     //Validation for price
     PRICE_MIN_VALUE = 0;
 
-    //Validation for coordinates
+    //Validation for location
     LONGITUDE_MIN_VALUE = -180
     LONGITUDE_MAX_VALUE = 180
     LATITUDE_MIN_VALUE = -90
@@ -61,7 +61,7 @@ module.exports = function({}) {
         return validationErrors
     }
 
-    exports.getAddChargePointValidation = function(name, address, coordinates) {
+    exports.getAddChargePointValidation = function(name, address, location) {
         const validationErrors = []
 
         if (name === undefined) {
@@ -74,16 +74,16 @@ module.exports = function({}) {
                 validationErrors.push("invalidName")
             }
         }
-        if (coordinates === undefined) {
-            validationErrors.push("invalidcoordinates")
+        if (location === undefined) {
+            validationErrors.push("invalidlocation")
         } else {
-            if ((coordinates instanceof Array) == false || (typeof coordinates[0] !== 'number') || (typeof coordinates[1] !== 'number')) {
+            if ((location instanceof Array) == false || (typeof location[0] !== 'number') || (typeof location[1] !== 'number')) {
                 validationErrors.push("invalidDataType")
             }
-            if (coordinates[0] < LATITUDE_MIN_VALUE || coordinates[0] > LATITUDE_MAX_VALUE) {
+            if (location[0] < LATITUDE_MIN_VALUE || location[0] > LATITUDE_MAX_VALUE) {
                 validationErrors.push("invalidLatitude")
             }
-            if (coordinates[1] < LONGITUDE_MIN_VALUE || coordinates[1] > LONGITUDE_MAX_VALUE) {
+            if (location[1] < LONGITUDE_MIN_VALUE || location[1] > LONGITUDE_MAX_VALUE) {
                 validationErrors.push("invalidLongitude")
             }
         }

--- a/backend-app/src/database-Interface/validation/charger-validation.js
+++ b/backend-app/src/database-Interface/validation/charger-validation.js
@@ -2,7 +2,7 @@ module.exports = function({}) {
     //Status codes
     const statusCodes = ["Available", "Preparing", "Charging", "SuspendedEVSE", "SuspendedEV", "Finishing", "Reserved", "Unavailable", "Faulted"]
 
-    //Validation for coordinates
+    //Validation for location
     LONGITUDE_MIN_VALUE = -180
     LONGITUDE_MAX_VALUE = 180
     LATITUDE_MIN_VALUE = -90
@@ -24,20 +24,20 @@ module.exports = function({}) {
         return validationErrors
     }
 
-    exports.getAddChargerValidation = function(coordinates, serialNumber, chargePointID) {
+    exports.getAddChargerValidation = function(location, serialNumber, chargePointID) {
 
         const validationErrors = []
 
-        if (coordinates === undefined || coordinates === null || coordinates.length !== 2) {
-            validationErrors.push("invalidCoordinates")
+        if (location === undefined || location === null || location.length !== 2) {
+            validationErrors.push("invalidlocation")
         } else {
-            if ((coordinates instanceof Array) == false || (typeof coordinates[0] !== 'number') || (typeof coordinates[1] !== 'number')) {
+            if ((location instanceof Array) == false || (typeof location[0] !== 'number') || (typeof location[1] !== 'number')) {
                 validationErrors.push("invalidDataType")
             }
-            if (coordinates[0] < LATITUDE_MIN_VALUE || coordinates[0] > LATITUDE_MAX_VALUE) {
+            if (location[0] < LATITUDE_MIN_VALUE || location[0] > LATITUDE_MAX_VALUE) {
                 validationErrors.push("invalidLatitude")
             }
-            if (coordinates[1] < LONGITUDE_MIN_VALUE || coordinates[1] > LONGITUDE_MAX_VALUE) {
+            if (location[1] < LONGITUDE_MIN_VALUE || location[1] > LONGITUDE_MAX_VALUE) {
                 validationErrors.push("invalidLongitude")
             }
         }

--- a/backend-app/src/presentation-layer/transaction-router-api.js
+++ b/backend-app/src/presentation-layer/transaction-router-api.js
@@ -94,7 +94,7 @@ module.exports = function ({ databaseInterfaceTransactions, verifyUser, dataAcce
 
         if (transactionID == 9999) {
             // 1/10 that charging is comleted
-            const data = getMockTransaction(Math.random() > 0.1, request.user.sub);
+            const data = getMockTransaction(false, request.user.sub);
             response.status(200).json(data);
             return;
         }

--- a/backend-app/src/testContainer.js
+++ b/backend-app/src/testContainer.js
@@ -5,7 +5,7 @@ function chargePointRepositoryMock() {
         chargePointID: 1,
         name: "Coop, Forserum",
         address: "Värnamovägen",
-        coordinates: [57.70022044183724, 14.475150415104222]
+        location: [57.70022044183724, 14.475150415104222]
     }
 
     return {
@@ -18,22 +18,22 @@ function chargePointRepositoryMock() {
         getChargePoints: function (callback) {
             callback([], [defaultItem])
         },
-        addChargePoint: function (name, address, coordinates, callback) {
+        addChargePoint: function (name, address, location, callback) {
             callback([], {
                 chargePointID: 2,
                 name,
                 address,
-                coordinates
+                location
             })
         },
         removeChargePoint: function (chargePointID, callback) {
             callback([], true)
         },
-        updateChargePoint: function (chargePointID, name, coordinates, address, callback) {
+        updateChargePoint: function (chargePointID, name, location, address, callback) {
             callback([], {
                 chargePointID,
                 name,
-                coordinates,
+                location,
                 address
             })
         }
@@ -101,7 +101,7 @@ function chargeSessionsRepositoryMock() {
 function chargersRepositoryMock() {
     const defaultItem = {
         connectorID: 100000,
-        coordinates: [57.749812214261034, 14.070100435207065],
+        location: [57.749812214261034, 14.070100435207065],
         serialNumber: "abc123",
         status: 'Available'
     }
@@ -125,12 +125,12 @@ function chargersRepositoryMock() {
         getAvailableChargers: function (callback) {
             callback([], [defaultItem])
         },
-        addCharger: function (chargePointID, serialNumber, coordinates, callback) {
+        addCharger: function (chargePointID, serialNumber, location, callback) {
             const newCharger = {
                 connectorID: 2,
                 chargePointID,
                 serialNumber,
-                coordinates,
+                location,
             }
 
             callback([], newCharger)


### PR DESCRIPTION
## Describe your changes

Add backwards compatibility

- A Charger now uses `location` instead of `coordinates`
- A ChargePoint now
  - uses `location` instead of `coordinates`
  - contains a `price`

## Issue ticket number and preferably a link

#226

## This change belongs to the following squad(s)
- [X] Database
- [X] HTTP
- OCPP

## I have created unit tests for my code
- Yes
- [X] No
- No, I need help with this

## Checklist before creating my pull request
- [X] My code is properly commented where needed
- [X] I have updated the documentation with my changes/additions
- [X] I have reviewed my code before creating this pull request
- [X] I have made sure that I am targeting the correct branch
